### PR TITLE
feat: 기록 상세보기 ui

### DIFF
--- a/findingbird-web/src/app/(..route)/record/detail/page.tsx
+++ b/findingbird-web/src/app/(..route)/record/detail/page.tsx
@@ -1,13 +1,11 @@
 // src/app/(..route)/record/page.tsx
 'use client';
 
-import React, { useState } from 'react';
-import { Dialog, DialogTrigger, DialogContent } from '@/app/ui/molecule/dialog/dialog';
-import { Close as DialogClose } from '@radix-ui/react-dialog';
+import React from 'react';
 import BirdCard from '@/app/ui/components/bird/bird-card';
 
 // RecordDetail 타입 정의
-interface RecordDetail {
+type RecordDetail = {
   id: number;
   date: string;                  // YYYY-MM-DD
   name: string | null;           // 발견한 새의 이름
@@ -17,13 +15,13 @@ interface RecordDetail {
   locationDescription: string;   // 위치 설명
   goalId: string | null;         // 목표 Id
   imageUrl: string;              // 사진 URL
-}
+};
 
 // 더미 레코드 데이터
 const dummyRecords: RecordDetail[] = [
   {
     id: 1,
-    date: '2025-05-07',
+    date: '2025-04-01',
     name: '집비둘기',
     district: '성북구',
     size: '중간',
@@ -32,85 +30,41 @@ const dummyRecords: RecordDetail[] = [
     goalId: 'goal-001',
     imageUrl: '/images/birds/rock-pigeon.jpg',
   },
-  {
-    id: 2,
-    date: '2025-05-07',
-    name: '직박구리',
-    district: '성북구',
-    size: '작음',
-    color: '올리브그린',
-    locationDescription: '성북천',
-    goalId: null,
-    imageUrl: '/images/birds/bulbul.jpg',
-  },
   // ... 추가 레코드
 ];
 
 export default function RecordPage() {
-  const [selectedRecord, setSelectedRecord] = useState<RecordDetail | null>(null);
-  const [isOpen, setIsOpen] = useState(false);
-
-  const openDialog = (rec: RecordDetail) => {
-    setSelectedRecord(rec);
-    setIsOpen(true);
-  };
-  const closeDialog = () => setIsOpen(false);
-
-  // modified: 선택된 기록의 날짜, 자치구, id로 페이지 상단 헤더 타이틀 동적 설정
-  const headerTitle = selectedRecord
-    ? `${selectedRecord.date} ${selectedRecord.district} #${selectedRecord.id}`
-    : '기록 상세 조회';
-
   return (
     <main className="min-h-screen bg-gray-100 p-5">
       <header className="mb-6">
-        <h1 className="text-2xl font-semibold text-gray-800">{headerTitle}</h1>
+        <h1 className="text-2xl font-semibold text-gray-800">기록 상세 목록</h1>
       </header>
 
-      <section className="grid grid-cols-1 gap-4">
+      <section className="space-y-8">
         {dummyRecords.map((rec) => (
-          <Dialog
-            key={rec.id}
-            open={isOpen && selectedRecord?.id === rec.id}
-            onOpenChange={(open) => { if (!open) closeDialog(); }}
-          >
-            <DialogTrigger asChild>
-              {/* modified: 클릭 시 openDialog 호출 */}
-              <div onClick={() => openDialog(rec)}>
-                <BirdCard // modified: 카드 가로 전체 사용을 위해 w-full 클래스 추가
-                  className="w-full"
-                  
-                  bird={{
-                    id: rec.id,
-                    imageUrl: rec.imageUrl,
-                    commonName: rec.name ?? '(알 수 없음)',
-                    scientificName: rec.district,
-                    morphology: '',
-                    ecology: '',
-                  }}
-                />
-              </div>
-            </DialogTrigger>
-            <DialogContent>
+          <article key={rec.id} className="bg-white rounded-lg shadow p-6">
+      
+    
+            {/* 상세 정보 */}
+            <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
               <img
                 src={rec.imageUrl}
                 alt={rec.name ?? ''}
-                className="mb-4 w-full h-auto object-cover rounded"
+                className="w-full h-auto object-cover rounded"
               />
-              <ul className="space-y-2">
+
+              <ul className="space-y-1 text-sm text-gray-700">
+                <li><strong>날짜:</strong> {rec.date}</li>
                 <li><strong>새 이름:</strong> {rec.name ?? '알 수 없음'}</li>
+                <li><strong>자치구:</strong> {rec.district}</li>
                 <li><strong>크기:</strong> {rec.size}</li>
                 <li><strong>색상:</strong> {rec.color}</li>
                 <li><strong>위치 설명:</strong> {rec.locationDescription}</li>
                 <li><strong>목표 ID:</strong> {rec.goalId ?? '없음'}</li>
+                <li><strong>Record ID:</strong> {rec.id}</li>
               </ul>
-              <DialogClose asChild>
-                <button className="w-full mt-4 text-center text-gray-700 hover:text-gray-900">
-                  닫기
-                </button>
-              </DialogClose>
-            </DialogContent>
-          </Dialog>
+            </div>
+          </article>
         ))}
       </section>
     </main>


### PR DESCRIPTION
하나의 기록 (ex. 2025-05-07 성북구 #2) 에 여러 조류의 관찰 기록이 한번에 뜨도록 구성하였음. 페이지 형태는 recommendation 과 유사함. add 할 때 하나씩 기록하도록 되어 있던데, 어떻게 하나의 관찰 페이지 안에 다 넣을지 생각해 보아야 할 듯함.